### PR TITLE
add QueryUserOnSite Tableau REST API call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+.idea
+*.iml

--- a/client.go
+++ b/client.go
@@ -119,6 +119,15 @@ func (api *API) querySite(url string) (Site, error) {
 	return retval.Site, err
 }
 
+//http://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm#REST/rest_api_ref.htm#Query_User_On_Site%3FTocPath%3DAPI%2520Reference%7C_____47
+func (api *API) QueryUserOnSite(siteId, userId string) (User, error) {
+	url := fmt.Sprintf("%s/api/%s/sites/%s/users/%s", api.Server, api.Version, siteId, userId)
+	headers := make(map[string]string)
+	retval := QueryUserOnSiteResponse{}
+	err := api.makeRequest(url, GET, nil, &retval, headers, connectTimeOut, readWriteTimeout)
+	return retval.User, err
+}
+
 //http://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm#REST/rest_api_ref.htm#Query_Projects%3FTocPath%3DAPI%2520Reference%7C_____38
 func (api *API) QueryProjects(siteId string) ([]Project, error) {
 	url := fmt.Sprintf("%s/api/%s/sites/%s/projects", api.Server, api.Version, siteId)

--- a/model.go
+++ b/model.go
@@ -96,6 +96,7 @@ type Datasource struct {
 	Type                  string                 `json:"type,omitempty" xml:"type,attr,omitempty"`
 	ConnectionCredentials *ConnectionCredentials `json:"connectionCredentials,omitempty" xml:"connectionCredentials,omitempty"`
 	Project               *Project               `json:"project,omitempty" xml:"project,omitempty"`
+	Owner                 *User                  `json:"owner,omitempty" xml:"owner,omitempty"`
 }
 
 type Datasources struct {
@@ -140,6 +141,9 @@ type Credentials struct {
 
 type User struct {
 	ID string `json:"id,omitempty" xml:"id,attr,omitempty"`
+	Name string `json:"name,omitempty" xml:"name,attr,omitempty"`
+	SiteRole string `json:"siteRole,omitempty" xml:"siteRole,attr,omitempty"`
+	FullName string `json:"fullName,omitempty" xml:"fullName,attr,omitempty"`
 }
 
 type QuerySitesResponse struct {
@@ -167,6 +171,18 @@ func (req QuerySiteResponse) XML() ([]byte, error) {
 		QuerySiteResponse
 		XMLName struct{} `xml:"tsRequest"`
 	}{QuerySiteResponse: req}
+	return xml.MarshalIndent(tmp, "", "   ")
+}
+
+type QueryUserOnSiteResponse struct {
+	User User `json:"user,omitempty" xml:"user,omitempty"`
+}
+
+func (req QueryUserOnSiteResponse) XML() ([]byte, error) {
+	tmp := struct {
+		QueryUserOnSiteResponse
+		XMLName struct{} `xml:"tsRequest"`
+	}{QueryUserOnSiteResponse: req}
 	return xml.MarshalIndent(tmp, "", "   ")
 }
 


### PR DESCRIPTION
i wanted to see the Name and SiteRole of the Datasource Owner.  So I added some fields to Datasource and User.  Then I added support for the QueryUserOnSite API call.  
