### PR TITLE
add ServerInfo Tableau REST API call

### DIFF
--- a/client.go
+++ b/client.go
@@ -74,6 +74,16 @@ func (api *API) Signout() error {
 	return err
 }
 
+//http://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm#REST/rest_api_ref.htm#Server_Info%3FTocPath%3DAPI%2520Reference%7C__
+func (api *API) ServerInfo() (ServerInfo, error) {
+	// this call only works on apiVersion 2.4 and up
+	url := fmt.Sprintf("%s/api/%s/serverinfo", api.Server, "2.4")
+	headers := make(map[string]string)
+	retval := ServerInfoResponse{}
+	err := api.makeRequest(url, GET, nil, &retval, headers, connectTimeOut, readWriteTimeout)
+	return retval.ServerInfo, err
+}
+
 //http://onlinehelp.tableau.com/current/api/rest_api/en-us/help.htm#REST/rest_api_ref.htm#Query_Sites%3FTocPath%3DAPI%2520Reference%7C_____40
 func (api *API) QuerySites() ([]Site, error) {
 	url := fmt.Sprintf("%s/api/%s/sites/", api.Server, api.Version)

--- a/model.go
+++ b/model.go
@@ -127,6 +127,15 @@ type AuthResponse struct {
 	Credentials *Credentials `json:"credentials,omitempty" xml:"credentials,omitempty"`
 }
 
+type ServerInfoResponse struct {
+	ServerInfo ServerInfo `json:"serverInfo,omitempty" xml:"serverInfo,omitempty"`
+}
+
+type ServerInfo struct {
+	ProductVersion string `json:"productVersion,omitempty" xml:"productVersion,omitempty"`
+	RestApiVersion string `json:"restApiVersion,omitempty" xml:"restApiVersion,omitempty"`
+}
+
 type QueryProjectsResponse struct {
 	Projects Projects `json:"projects,omitempty" xml:"projects,omitempty"`
 }


### PR DESCRIPTION
added support for /serverinfo endpoint introduced in tableau server 10.1 (rest api v2.4).
